### PR TITLE
Allows custom object properties to use a converter if one is registered.

### DIFF
--- a/src/SqlFu/PocoFactory.cs
+++ b/src/SqlFu/PocoFactory.cs
@@ -201,7 +201,10 @@ namespace SqlFu
                 if (prop == null) continue;
                 if (prop.PropertyType.IsCustomObjectType())
                 {
-                    if (!prop.PropertyType.Implements<IEnumerable>()) continue;
+                    //check if the property type is an IEnumerable or has a converter registered (there may be a registered converter for a class)
+                    bool isEnumerable = prop.PropertyType.Implements<IEnumerable>();
+                    bool hasConverter = _converters.ContainsKey(prop.PropertyType.GetHashCode());
+                    if (!isEnumerable && !hasConverter) continue;
                 }
 
                 //throw new InvalidCastException(string.Format("Can't convert {0} to {1} ",rd.GetFieldType(i).ToString(),prop.PropertyType.ToString()));

--- a/src/Tests/QueryTests.cs
+++ b/src/Tests/QueryTests.cs
@@ -154,6 +154,14 @@ namespace Tests.Helpers
 
         }
 
+        [Fact]
+        public void global_custom_converter()
+        {
+            PocoFactory.RegisterConverterFor<CustomObject>(o => new CustomObject(o.ToString()));
+            var custom = _db.GetValue<CustomObject>("select 'custom-value'");
+            Assert.Equal("custom-value", custom.CustomValue);
+        }
+
         private void Write(object format, params object[] param)
         {
             Console.WriteLine(format.ToString(), param);
@@ -162,6 +170,18 @@ namespace Tests.Helpers
         public void Dispose()
         {
            Config.EmptyTable();
+        }
+
+
+
+        public class CustomObject
+        {
+            public string CustomValue { get; private set; }
+
+            public CustomObject(string customValue)
+            {
+                CustomValue = customValue;
+            }
         }
     }
 }


### PR DESCRIPTION
PR to implement request for issue: https://github.com/sapiens/SqlFu/issues/16

I couldn't get the tests to run due to the missing SQLite DB, but I do have this exact code working in production for a month or so now.

Here are 2 examples for registering converters for properties of a custom object type. Properties of these types on my models map to a string ("ME", "OA", etc.) and a char ('I', 'S', etc.) respectively. In this case, these types descend from the Enumeration class found here: https://github.com/HeadspringLabs/Enumeration/

``` csharp
PocoFactory.RegisterConverterFor(o => QuizAnswerType.FromValue(o.ToString()));
PocoFactory.RegisterConverterFor(o => QuizFeedbackType.FromValue(o.ToString()[0]));

public class QuizAnswerType : Enumeration<QuizAnswerType, string> { ... }
public class QuizFeedbackType : Enumeration<QuizFeedbackType, char> { ... }
```

The above classes for properties on my models, with the code in this PR, have been working in a production website for over a month now. I hope this is helpful to others.
