### PR TITLE
Added new Fetch methods for multiple resultsets and...

### DIFF
--- a/src/SqlFu/SqlFuDao.cs
+++ b/src/SqlFu/SqlFuDao.cs
@@ -71,7 +71,7 @@ namespace SqlFu
             }
         }
 
-        internal static DbCommand CreateAndSetupCommand(this DbConnection cnx, string sql, params object[] args)
+        public static DbCommand CreateAndSetupCommand(this DbConnection cnx, string sql, params object[] args)
         {
             var provider = cnx.GetProvider();
             var cmd = cnx.CreateCommand();
@@ -79,6 +79,117 @@ namespace SqlFu
             statement.Setup(cmd);
             return cmd;
         }
+
+        #region Multiple Resultsets
+
+        public static Tuple<IList<T1>, IList<T2>> Fetch<T1, T2>(this DbConnection cnx, string sql, params object[] args)
+            where T1 : new() where T2 : new()
+        {
+            using (var cmd = cnx.CreateAndSetupCommand(sql, args))
+            {
+                using (var reader = cmd.ExecuteReader())
+                {
+                    var list1 = MapReaderToModel<T1>(reader, cmd);
+                    var list2 = MapReaderToModel<T2>(reader, cmd, true);
+
+                    return new Tuple<IList<T1>, IList<T2>>(list1, list2);
+                }
+            }
+        }
+
+        public static Tuple<IList<T1>, IList<T2>, IList<T3>> Fetch<T1, T2, T3>(this DbConnection cnx, string sql, params object[] args)
+            where T1 : new() where T2 : new() where T3 : new()
+        {
+            using (var cmd = cnx.CreateAndSetupCommand(sql, args))
+            {
+                using (var reader = cmd.ExecuteReader())
+                {
+                    var list1 = MapReaderToModel<T1>(reader, cmd);
+                    var list2 = MapReaderToModel<T2>(reader, cmd, true);
+                    var list3 = MapReaderToModel<T3>(reader, cmd, true);
+
+                    return new Tuple<IList<T1>, IList<T2>, IList<T3>>(list1, list2, list3);
+                }
+            }
+        }
+
+        public static Tuple<IList<T1>, IList<T2>, IList<T3>, IList<T4>> Fetch<T1, T2, T3, T4>(this DbConnection cnx, string sql, params object[] args)
+            where T1 : new() where T2 : new() where T3 : new() where T4 : new()
+        {
+            using (var cmd = cnx.CreateAndSetupCommand(sql, args))
+            {
+                using (var reader = cmd.ExecuteReader())
+                {
+                    var list1 = MapReaderToModel<T1>(reader, cmd);
+                    var list2 = MapReaderToModel<T2>(reader, cmd, true);
+                    var list3 = MapReaderToModel<T3>(reader, cmd, true);
+                    var list4 = MapReaderToModel<T4>(reader, cmd, true);
+
+                    return new Tuple<IList<T1>, IList<T2>, IList<T3>, IList<T4>>(list1, list2, list3, list4);
+                }
+            }
+        }
+
+        public static Tuple<IList<T1>, IList<T2>, IList<T3>, IList<T4>, IList<T5>> Fetch<T1, T2, T3, T4, T5>(this DbConnection cnx, string sql, params object[] args)
+            where T1 : new() where T2 : new() where T3 : new() where T4 : new() where T5 : new()
+        {
+            using (var cmd = cnx.CreateAndSetupCommand(sql, args))
+            {
+                using (var reader = cmd.ExecuteReader())
+                {
+                    var list1 = MapReaderToModel<T1>(reader, cmd);
+                    var list2 = MapReaderToModel<T2>(reader, cmd, true);
+                    var list3 = MapReaderToModel<T3>(reader, cmd, true);
+                    var list4 = MapReaderToModel<T4>(reader, cmd, true);
+                    var list5 = MapReaderToModel<T5>(reader, cmd, true);
+        
+                    return new Tuple<IList<T1>, IList<T2>, IList<T3>, IList<T4>, IList<T5>>(list1, list2, list3, list4, list5);
+                }
+            }
+        }
+
+        public static Tuple<IList<T1>, IList<T2>, IList<T3>, IList<T4>, IList<T5>, IList<T6>> Fetch<T1, T2, T3, T4, T5, T6>(this DbConnection cnx, string sql, params object[] args)
+            where T1 : new() where T2 : new() where T3 : new() where T4 : new() where T5 : new() where T6 : new()
+        {
+            using (var cmd = cnx.CreateAndSetupCommand(sql, args))
+            {
+                using (var reader = cmd.ExecuteReader())
+                {
+                    var list1 = MapReaderToModel<T1>(reader, cmd);
+                    var list2 = MapReaderToModel<T2>(reader, cmd, true);
+                    var list3 = MapReaderToModel<T3>(reader, cmd, true);
+                    var list4 = MapReaderToModel<T4>(reader, cmd, true);
+                    var list5 = MapReaderToModel<T5>(reader, cmd, true);
+                    var list6 = MapReaderToModel<T6>(reader, cmd, true);
+
+                    return new Tuple<IList<T1>, IList<T2>, IList<T3>, IList<T4>, IList<T5>, IList<T6>>(list1, list2, list3, list4, list5, list6);
+                }
+            }
+        }
+
+
+        internal static IList<TModel> MapReaderToModel<TModel>(IDataReader reader, IDbCommand command, bool useNextResult = false)
+        {
+            var results = new List<TModel>();
+
+            if (useNextResult)
+            {
+                if (!reader.NextResult())
+                {
+                    return results;
+                }
+            }
+
+            while (reader.Read())
+            {
+                var mapper = PocoFactory.GetPocoMapper<TModel>(reader, command.CommandText);
+                results.Add(mapper(reader));
+            }
+
+            return results;
+        }
+
+        #endregion
 
         #region Settings
 


### PR DESCRIPTION
...increased visibility of CreateAndSetupCommand so users can create other extension methods to suit their needs.

These methods are described in the discussion for issue: https://github.com/sapiens/SqlFu/issues/6.

If this isn't suitable, I encourage at least increasing CreateAndSetupCommand's visibility to public for the sake of doing something like this in users' own code. Also, tests are an issue with the SQLite database used in the existing tests. However, I've also been using this code in production for over a month now with great results. Here's an example:

``` csharp
public IList<QuizInfo> GetQuizzesForIds(IEnumerable<Guid> quizIds)
{
    var args = new { QuizIds = quizIds };
    string test = "select * from Quiz where Id in (@QuizIds); " +
                  "select * from Question where QuizId in (@QuizIds); " +
                  "select * from Answer A inner join Question Q on A.QuestionId = Q.Id where Q.QuizId in (@QuizIds);";

    var result = Fetch<QuizInfo, QuizQuestionInfo, QuizAnswerInfo>(sql, args);
    var allQuizzes = result.Item1;
    var allQuestions = result.Item2;
    var allAnswers = result.Item3;

    foreach (QuizInfo quiz in allQuizzes) {
        Guid quizId = quiz.Id;
        var questions = allQuestions.Where(q => q.QuizId == quizId).ToList();
        quiz.Questions = questions;

        foreach (QuizQuestionInfo question in questions) {
            Guid questionId = question.Id;
            var answers = allAnswers.Where(a => a.QuestionId == questionId).ToList();
            question.Answers = answers;
        }
    }

    return allQuizzes;
}
```
