### PR TITLE
Ability to move SqlFu-specific attributes from POCO's to their metadata buddy classes

### DIFF
--- a/src/SqlFu/Utils.cs
+++ b/src/SqlFu/Utils.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Text;
+using System.Reflection;
+using System.ComponentModel.DataAnnotations;
 
 namespace SqlFu
 {
@@ -53,5 +55,50 @@ namespace SqlFu
             return !(t is ValueType) && (Type.GetTypeCode(t.GetType()) == TypeCode.Object);
         }
        
+        /// <summary>
+        /// Enhances the <see cref="GetSingleAttribute<T>"/> extension introduced in CavemanTools assembly by 
+        /// adding the alsoCheckMetadataType parameter that controls if a metadata buddy class will be searched
+        /// for the attribute of type T in case it's not defined in the original POCO class. The idea here is
+        /// to keep POCO's SqlFu agnostic by moving SqlFu attributes to a buddy class.
+        /// </summary>
+        public static T GetSingleAttribute<T>(this ICustomAttributeProvider self, bool alsoCheckMetadataType) where T : Attribute
+        {
+            // Try to get the attribute from self first.
+            var result = self.GetSingleAttribute<T>();
+
+            if (result == null && alsoCheckMetadataType)
+            {
+                // Attribute not found on self, so look for it in the metadata buddy class.
+                if (self is PropertyInfo)
+                {
+                    // Looking up a property attribute.
+                    var propInfo = (PropertyInfo)self;
+                    var propIndexParams = propInfo.GetIndexParameters();
+                    List<Type> propIndexTypes = new List<Type>();
+                    if (propIndexParams != null)
+                    {
+                        foreach (var p in propIndexParams)
+                        {
+                            propIndexTypes.Add(p.ParameterType);
+                        }
+                    }
+                    var metaTypeAttr = propInfo.DeclaringType.GetSingleAttribute<MetadataTypeAttribute>();
+                    if (metaTypeAttr != null)
+                    {
+                        var metaProp = metaTypeAttr.MetadataClassType.GetProperty(propInfo.Name, propInfo.PropertyType, propIndexTypes.ToArray());
+                        if (metaProp != null)
+                            result = metaProp.GetSingleAttribute<T>();
+                    }
+                }
+                else
+                {
+                    // Looking up a class attribute.
+                    var metaTypeAttr = self.GetSingleAttribute<MetadataTypeAttribute>();
+                    if (metaTypeAttr != null)
+                        result = metaTypeAttr.MetadataClassType.GetSingleAttribute<T>();
+                }
+            }
+            return result;
+        }
     }
 }


### PR DESCRIPTION
I don't like decorating my POCO's with data-access-specific attributes, and one way to keep them agnostic is by adding a metadata buddy class using the [MetadataType] attribute and applying all class- and member-level attributes (validation, data-access-related, etc.) in the buddy class. In order for these metadata attributes to be recognized by TableInfo.cs I have added an enhanced version of your GetSingleAttribute<T> extension method that checks the metadata buddy class (if one exists) for an attribute if it fails to find it in the main class. Here's this enhanced method. I will also add corresponding changes to the TableInfo.cs class.
