### PR TITLE
Support for storing SqlFu-specific attributes in metadata classes

### DIFF
--- a/src/SqlFu/Internals/TableInfo.cs
+++ b/src/SqlFu/Internals/TableInfo.cs
@@ -34,7 +34,7 @@ namespace SqlFu.Internals
         {
             if (t.IsValueType || t == typeof (object))
                 throw new InvalidOperationException("A table can't be System.Object or just a value");
-            var tab = t.GetSingleAttribute<TableAttribute>();
+            var tab = t.GetSingleAttribute<TableAttribute>(true);
             if (tab != null)
             {
                 Name = tab.Name;
@@ -55,12 +55,12 @@ namespace SqlFu.Internals
             {
                 foreach (var p in t.GetProperties())
                 {
-                    var qr = p.GetSingleAttribute<QueryOnlyAttribute>();
+                    var qr = p.GetSingleAttribute<QueryOnlyAttribute>(true);
                     if (qr != null)
                     {
                         exclude.Add(p.Name);
                     }
-                    var tos = p.GetSingleAttribute<InsertAsStringAttribute>();
+                    var tos = p.GetSingleAttribute<InsertAsStringAttribute>(true);
                     if (tos != null)
                     {
                         tstring.Add(p.Name);


### PR DESCRIPTION
Resubmitting the pull request originally made in the master branch (https://github.com/sapiens/SqlFu/pull/23):

"I don't like decorating my POCO's with data-access-specific attributes, and one way to keep them agnostic is by adding a metadata buddy class using the [MetadataType] attribute and applying all class- and member-level attributes (validation, data-access-related, etc.) in the buddy class. In order for these metadata attributes to be recognized by TableInfo.cs I have added an enhanced version of your GetSingleAttribute extension method that checks the metadata buddy class (if one exists) for an attribute if it fails to find it in the main class. Here's this enhanced method. I will also add corresponding changes to the TableInfo.cs class."
