### PR TITLE
SQLite DDL fixes

### DIFF
--- a/src/SqlFu/DDL/Generators/Sqlite/SqliteColumnWriter.cs
+++ b/src/SqlFu/DDL/Generators/Sqlite/SqliteColumnWriter.cs
@@ -112,12 +112,22 @@ namespace SqlFu.DDL.Generators.Sqlite
         {
             return "integer";
         }
+        
+		protected override string SmallInt()
+		{
+			return "integer";
+		}
+		
+		protected override string BigInt()
+		{
+			return "integer";
+		}
+		
 
         protected override string DateTimeOffset(string size)
         {
             return String(null);
         }
-
         #endregion
     }
 }

--- a/src/SqlFu/DDL/Generators/Sqlite/SqliteDDLWriter.cs
+++ b/src/SqlFu/DDL/Generators/Sqlite/SqliteDDLWriter.cs
@@ -29,11 +29,11 @@ namespace SqlFu.DDL.Generators.Sqlite
 
         protected override void WriteTableName()
         {
-            Builder.Append(Escape(Table.Name));
             if (Table.CreationOption == IfTableExists.Ignore)
             {
-                Builder.Append(" if not exists");
+                Builder.Append("if not exists ");
             }
+            Builder.Append(Escape(Table.Name));
         }
 
         protected override AbstractColumnWriter GetColumnWriter()

--- a/src/Tests/DDL/CommonCreateTableTests.cs
+++ b/src/Tests/DDL/CommonCreateTableTests.cs
@@ -32,8 +32,19 @@ namespace Tests.DDL
             Table = Db.DatabaseTools.GetCreateTableBuilder(TableName,IfTableExists.Throw);
             Table.Columns
                 .Add("Id", DbType.Int32, isNullable: false, autoIncrement: true).AsPrimaryKey("pk_test")
-                .Add("Name", DbType.String, size: "50").AsUnique("uk_name")//.WithCheck("Name like '%a'","ck_name")
-                .Add("Uid", DbType.Guid);
+                .Add("Name", DbType.String, size: "50").AsUnique("uk_name")//.WithCheck("Name like '%a'","ck_name")+            	
+            	.Add("Uid", DbType.Guid)
+            	.Add("Int32", DbType.Int32)
+            	.Add("Int64", DbType.Int64)
+            	.Add("Int16", DbType.Int16)
+            	.Add("UInt16", DbType.UInt16)
+	          	.Add("UInt32", DbType.UInt32)
+            	.Add("UInt64", DbType.UInt64)
+	           	.Add("Single", DbType.Single)
+            	.Add("Double", DbType.Double)
+            	.Add("DateTime", DbType.DateTime)
+            	.Add("DateTimeOffset", DbType.DateTimeOffset);
+
             Table.TableOptionsFor(DbEngine.MySql, MySqlOptions.Table.AutoIncrementValueIs(1),MySqlOptions.Table.EngineIs(TableEngineType.InnoDb));
             Table.Constraints.AddCheck("Name like '%a'", "ck_name")
                  .IfDatabaseIs(DbEngine.PostgreSQL).Redefine("constraint ck_name check(\"Name\" like '%a')");


### PR DESCRIPTION
Fixed some bugs with SQLite's DDL implementation specifically:
- Column types of Int64 and Int16 now use the "Integer" sqlite data
  type (bigint is not a valid sqlite data type).
- Fixed If Table Exists Ignore functionality for SQlite (for sqlite 'if not exists' must be before the table name not after).
- Added a number of columns to standard test case to make sure other
  data types are working correctly.

Note: the SqlFu45 project, loaded from SqlFu.sln, includes some missing files. Specifically: `obj\Debug\TemporaryGeneratedFile_{-----}.cs` which I had to delete so I could compile the project. However I haven't included these changes in the pull request since I have no idea if these were required or not.
