### PR TITLE
Fixing Table creations on *nix OS

### DIFF
--- a/src/SqlFu/DDL/Generators/CommonDDLWriter.cs
+++ b/src/SqlFu/DDL/Generators/CommonDDLWriter.cs
@@ -127,7 +127,7 @@ namespace SqlFu.DDL.Generators
                     Builder.AppendLine().Append(ch).AppendLine(",");
                 }
             }
-            Builder.RemoveLastIfEquals(",\r\n");
+            Builder.RemoveLastIfEquals("," + Environment.NewLine);
         }
 
         protected virtual string GetAddConstraintPrefix()


### PR DESCRIPTION
StringBuilder.AppendLine() is using Environment.NewLine which is "\n" on *nix and "\r\n" on Windows.
