### PR TITLE
Fix "Operation could destabilize the runtime" error when passing a dicti...

### DIFF
--- a/src/SqlFu/CrudHelpers.cs
+++ b/src/SqlFu/CrudHelpers.cs
@@ -43,7 +43,12 @@ namespace SqlFu
             var provider = db.GetProvider();
             List<object> args = null;
 
-            var arguments = data.ToDictionary();
+            IDictionary<string, object> arguments;
+            if (data.GetType().GetInterfaces().Contains(typeof(IDictionary<string, object>)))
+                arguments = (IDictionary<string, object>)data;
+            else
+                arguments = data.ToDictionary();
+
             if (tableInfo.InsertSql == null)
             {
                 var sb = new StringBuilder("Insert into");


### PR DESCRIPTION
Workaround for what appears to be a bug in CavemanTools - if .ToDictionary() is called on a dictionary, it will fail with the rather uninformative exception "Operation could destabilize the runtime". This works around it by simply checking if the data object implements IDictionary<string, object> and if so, not running ToDictionary() on it, since it doesn't need to be converted anyway.
