### PR TITLE
Changed GetPocoMapper method to public availability

### DIFF
--- a/src/SqlFu/PocoFactory.cs
+++ b/src/SqlFu/PocoFactory.cs
@@ -103,7 +103,7 @@ namespace SqlFu
         }
 
 
-        internal static Func<IDataReader, T> GetPocoMapper<T>(IDataReader rd, string sql)
+        public static Func<IDataReader, T> GetPocoMapper<T>(IDataReader rd, string sql)
         {
             var poco = typeof (T);
 


### PR DESCRIPTION
Allowing access to this method means that using Fetch method can be extended outside the library to get additional information from the data reader whilst still being able to use the SqlFu mapping features.

As an example, I'm using this in order to query a stored procedure for paged results along with total row counts that can not be passed back efficiently via traditional output parameters.

Making the GetPocoMapper public allows for greater flexibility and power from the SqlFu library